### PR TITLE
Ignore examples dir

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -16,7 +16,7 @@ runs:
       env:
         HADOLINT_VERSION: 2.12.0-alpine
       shell: bash
-      run: find . -name "Dockerfile*" -print  | xargs -r -n1 docker run -v "$PWD":/work -w /work "hadolint/hadolint:${HADOLINT_VERSION}" hadolint
+      run: find . -path "./examples" -prune -o -name "Dockerfile.*" -print | xargs -r -n1 docker run -v "$PWD":/work -w /work "hadolint/hadolint:${HADOLINT_VERSION}" hadolint
 
     - name: renovate-validate
       env:
@@ -28,8 +28,8 @@ runs:
       env:
         SHELLCHECK_VERSION: v0.9.0
       shell: bash
-      run: find . -name "*.sh" -print  | xargs -r -n1 docker run -v "$PWD":/work -w /work "koalaman/shellcheck-alpine:${SHELLCHECK_VERSION}" shellcheck
+      run: find . -path "./examples" -prune -o -name "*.sh" -print | xargs -r -n1 docker run -v "$PWD":/work -w /work "koalaman/shellcheck-alpine:${SHELLCHECK_VERSION}" shellcheck
 
     - name: yamllint
       shell: bash
-      run: find . -name "*.yml" -or -name "*.yaml" -print  | xargs -r -n1 docker run -v "$PWD":/work -w /work cytopia/yamllint
+      run: find . -path "./examples" -prune -o -name "*.yml" -or -name "*.yaml" -print  | xargs -r -n1 docker run -v "$PWD":/work -w /work cytopia/yamllint


### PR DESCRIPTION
Some of the files on the examples are making master fail related to lintin issues, but IMO the examples dir doesn't need to comply to the same linting standards so I would like to ignore them. WDYT?